### PR TITLE
Fix profile upload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,8 @@ import * as bodyParser from 'body-parser';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  app.use(bodyParser.json({ limit: '5mb' }));
-  app.use(bodyParser.urlencoded({ limit: '5mb', extended: true }));
+  app.use('/user/profile/image', bodyParser.json({ limit: '5mb' }));
+  app.use('/user/profile/image', bodyParser.urlencoded({ limit: '5mb', extended: true }));
   const config = new DocumentBuilder()
     .setTitle('Aegis Health Application')
     .setDescription('Aegis Health API Application')

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,22 @@
-import { NestFactory } from '@nestjs/core'
-import { AppModule } from './app.module'
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
-
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as bodyParser from 'body-parser';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-
+  app.use(bodyParser.json({ limit: '5mb' }));
+  app.use(bodyParser.urlencoded({ limit: '5mb', extended: true }));
   const config = new DocumentBuilder()
     .setTitle('Aegis Health Application')
-    .setDescription("Aegis Health API Application")
+    .setDescription('Aegis Health API Application')
     .setVersion('1.0')
     .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup("api/doc", app, document)
+  SwaggerModule.setup('api/doc', app, document);
 
   await app.listen(process.env.PORT || 8080);
 }
-bootstrap()
+bootstrap();

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -62,8 +62,16 @@ export class UploadProfileResponse {
   url: string;
 }
 export class UploadProfileRequest {
+  @ApiProperty()
+  @IsString()
   base64: string;
+  @ApiProperty()
+  @IsString()
   name: string;
+  @ApiProperty()
+  @IsString()
   type: string;
+  @ApiProperty()
+  @IsNumber()
   size: number;
 }

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -61,3 +61,9 @@ export class UploadProfileResponse {
   @IsString()
   url: string;
 }
+export class UploadProfileRequest {
+  base64: string;
+  name: string;
+  type: string;
+  size: number;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -14,7 +14,16 @@ import {
   UploadedFile,
 } from '@nestjs/common';
 import { UserService } from './user.service';
-import { UserDto, UpdateRelationshipDto, LoginDto, CreateUserDto, AuthResponse, UploadProfileResponse, UpdateUserProfileDto } from './dto/user.dto';
+import {
+  UserDto,
+  UpdateRelationshipDto,
+  LoginDto,
+  CreateUserDto,
+  AuthResponse,
+  UploadProfileResponse,
+  UpdateUserProfileDto,
+  UploadProfileRequest,
+} from './dto/user.dto';
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -146,11 +155,12 @@ export class UserController {
   @ApiBearerAuth()
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @Post('profile/image')
+  @ApiBody({ type: UploadProfileRequest })
   @ApiOkResponse({ type: UploadProfileResponse })
   @ApiBadRequestResponse({ description: 'Image too large' })
   @ApiUnsupportedMediaTypeResponse({ description: 'Invalid image type' })
-  async uploadProfilePicture(@Request() req): Promise<UploadProfileResponse> {
-    const imageUrl = await this.userService.uploadProfilePicture(req.user.uid, req.body._parts[0][1]);
+  async uploadProfilePicture(@Body() dto: UploadProfileRequest, @Request() req): Promise<UploadProfileResponse> {
+    const imageUrl = await this.userService.uploadProfilePicture(req.user.uid, dto);
     return imageUrl;
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -145,13 +145,12 @@ export class UserController {
   @UseGuards(UserGuard)
   @ApiBearerAuth()
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 20000000 } }))
   @Post('profile/image')
   @ApiOkResponse({ type: UploadProfileResponse })
   @ApiBadRequestResponse({ description: 'Image too large' })
   @ApiUnsupportedMediaTypeResponse({ description: 'Invalid image type' })
-  async uploadProfilePicture(@UploadedFile() file: Express.Multer.File, @Request() req): Promise<UploadProfileResponse> {
-    const imageUrl = await this.userService.uploadProfilePicture(req.user.uid, file);
+  async uploadProfilePicture(@Request() req): Promise<UploadProfileResponse> {
+    const imageUrl = await this.userService.uploadProfilePicture(req.user.uid, req.body._parts[0][1]);
     return imageUrl;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -130,7 +130,6 @@ export class UserService {
       throw new BadRequestException('Image too large');
     }
     const buffer = Buffer.from(image.base64);
-    console.log(buffer);
     const imageUrl = await this.googleStorageService.uploadImage(foundUid, buffer);
     const { imageid } = await this.userRepository.save({
       uid: foundUid,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -126,10 +126,10 @@ export class UserService {
     if (!image || !ALLOWED_PROFILE_FORMAT.includes(image.type)) {
       throw new UnsupportedMediaTypeException('Invalid image type');
     }
-    if (image.size > 20000000) {
+    const buffer = Buffer.from(image.base64);
+    if (buffer.byteLength > 20000000) {
       throw new BadRequestException('Image too large');
     }
-    const buffer = Buffer.from(image.base64);
     const imageUrl = await this.googleStorageService.uploadImage(foundUid, buffer);
     const { imageid } = await this.userRepository.save({
       uid: foundUid,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -127,7 +127,7 @@ export class UserService {
       throw new UnsupportedMediaTypeException('Invalid image type');
     }
     const buffer = Buffer.from(image.base64);
-    if (buffer.byteLength > 20000000) {
+    if (buffer.byteLength > 5000000) {
       throw new BadRequestException('Image too large');
     }
     const imageUrl = await this.googleStorageService.uploadImage(foundUid, buffer);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, UnsupportedMediaTypeException } from '
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../entities/user.entity';
 import { FindConditions, FindOneOptions, Repository } from 'typeorm';
-import { UpdateRelationshipDto, CreateUserDto, IDto, UploadProfileResponse } from './dto/user.dto';
+import { UpdateRelationshipDto, CreateUserDto, IDto, UploadProfileResponse, UploadProfileRequest } from './dto/user.dto';
 import { DuplicateElementException, InvalidUserTypeException, UserNotFoundException } from './user.exception';
 import { plainToInstance } from 'class-transformer';
 import { AuthService } from 'src/auth/auth.service';
@@ -121,15 +121,17 @@ export class UserService {
     return res;
   }
 
-  async uploadProfilePicture(uid: number, image: Express.Multer.File): Promise<UploadProfileResponse> {
+  async uploadProfilePicture(uid: number, image: UploadProfileRequest): Promise<UploadProfileResponse> {
     const { uid: foundUid } = await this.findOne({ uid: uid }, { shouldExist: true });
-    if (!image || !ALLOWED_PROFILE_FORMAT.includes(image.mimetype)) {
+    if (!image || !ALLOWED_PROFILE_FORMAT.includes(image.type)) {
       throw new UnsupportedMediaTypeException('Invalid image type');
     }
     if (image.size > 20000000) {
       throw new BadRequestException('Image too large');
     }
-    const imageUrl = await this.googleStorageService.uploadImage(foundUid, image.buffer);
+    const buffer = Buffer.from(image.base64);
+    console.log(buffer);
+    const imageUrl = await this.googleStorageService.uploadImage(foundUid, buffer);
     const { imageid } = await this.userRepository.save({
       uid: foundUid,
       imageid: imageUrl,

--- a/src/utils/global.constant.ts
+++ b/src/utils/global.constant.ts
@@ -1,1 +1,1 @@
-export const ALLOWED_PROFILE_FORMAT = ['image/png', 'image/jpeg', 'image/heic', 'image/heif'];
+export const ALLOWED_PROFILE_FORMAT = ['image/png', 'image/jpeg', 'image/heic', 'image/heif', 'image/jpg'];


### PR DESCRIPTION
- Set limit for request body to 5 MB (for images) for POST `user/profile/image`
- Migrate to traditional POST request payload body for transferring image since NestJS file interceptor cannot intercept `FormData` sent from React Native