### PR TITLE
Offset time check by 7 for GMT+7

### DIFF
--- a/src/reminder/reminder.service.ts
+++ b/src/reminder/reminder.service.ts
@@ -498,7 +498,7 @@ export class ReminderService {
 
     if (!reminder) throw new HttpException('Reminder not found', HttpStatus.NOT_FOUND);
     if (reminder.isDone) throw new HttpException('This reminder is already completed', HttpStatus.CONFLICT);
-    if (reminder.startingDateTime.getTime() - currentDate.getTime() > 1800000)
+    if (moment(reminder.startingDateTime).add(-7, 'h').toDate().getTime() - currentDate.getTime() > 1800000)
       throw new HttpException('Can not mark reminder in advance over 30 minutes', HttpStatus.CONFLICT);
     if (reminder.recurrings.length !== 0) throw new HttpException('Can not mark reminder that have recurring', HttpStatus.CONFLICT);
 


### PR DESCRIPTION
Due to the agreement that everything related to reminder will have their time offset by 7, markAsComplete service must be adjusted accordingly. 

- shift startingDateTime by -7 during the 30 min advance check